### PR TITLE
支持LaTeX模板中提供的字体组功能，更新CUTI版本

### DIFF
--- a/layouts/doc.typ
+++ b/layouts/doc.typ
@@ -1,3 +1,6 @@
+#import "@preview/cuti:0.3.0": show-cn-fakebold
+#import "../utils/globals.typ": fontset
+
 // 文稿设置，可以进行一些像页面边距这类的全局设置
 #let doc(
   // documentclass 传入参数
@@ -34,6 +37,9 @@
     title: (("",) + info.title).sum(),
     author: info.author,
   )
+
+  // 5.  中文伪加粗（针对没有粗体的字体）
+  show: show-cn-fakebold
 
   it
 }

--- a/layouts/doc.typ
+++ b/layouts/doc.typ
@@ -39,7 +39,13 @@
   )
 
   // 5.  中文伪加粗（针对没有粗体的字体）
-  show: show-cn-fakebold
-
-  it
+  // Fandol系字体自带粗体，因此不需要伪加粗
+  if fontset != "fandol" {
+    {
+      show: show-cn-fakebold
+      it
+    }
+  } else {
+    it
+  }
 }

--- a/lib.typ
+++ b/lib.typ
@@ -23,7 +23,6 @@
 #import "pages/notation.typ": notation
 #import "pages/acknowledgement.typ": acknowledgement // 致谢部分
 #import "pages/backmatter.typ": backmatter // 致谢部分
-#import "utils/custom-cuti.typ": *
 #import "utils/bilingual-bibliography.typ": bilingual-bibliography
 #import "utils/custom-numbering.typ": custom-numbering
 #import "utils/custom-heading.typ": heading-display, active-heading, current-heading

--- a/pages/bachelor-abstract-en.typ
+++ b/pages/bachelor-abstract-en.typ
@@ -1,4 +1,3 @@
-#import "../utils/custom-cuti.typ": fakebold
 #import "../utils/style.typ": 字号, 字体
 #import "../utils/indent.typ": fake-par
 #import "../utils/double-underline.typ": double-underline
@@ -59,7 +58,7 @@
 
       #v(1em)
 
-      #double-underline[#fakebold[中国科学院大学本科生毕业论文（设计、作品）英文摘要]]
+      #double-underline[*中国科学院大学本科生毕业论文（设计、作品）英文摘要*]
     ]
 
     #v(2pt)

--- a/pages/bachelor-abstract.typ
+++ b/pages/bachelor-abstract.typ
@@ -1,4 +1,3 @@
-#import "../utils/custom-cuti.typ": fakebold
 #import "../utils/style.typ": 字号, 字体
 #import "../utils/indent.typ": fake-par
 #import "../utils/double-underline.typ": double-underline
@@ -59,31 +58,31 @@
 
       #v(1em)
 
-      #double-underline[#fakebold[中国科学院大学本科生毕业论文（设计、作品）中文摘要]]
+      #double-underline[*中国科学院大学本科生毕业论文（设计、作品）中文摘要*]
     ]
 
-    #fakebold[题目：]#info-value("title", (("",)+ info.title).sum())
+    *题目：*#info-value("title", (("",)+ info.title).sum())
 
-    #fakebold[院系：]#info-value("department", info.department)
+    *院系：*#info-value("department", info.department)
 
-    #fakebold[专业：]#info-value("major", info.major)
+    *专业：*#info-value("major", info.major)
 
-    #fakebold[本科生姓名：]#info-value("author", info.author)
+    *本科生姓名：*#info-value("author", info.author)
 
-    #fakebold[指导教师（姓名、职称）：]#info-value("supervisor", info.supervisor.at(0) + info.supervisor.at(1)) #(if info.supervisor-ii != () [#h(1em) #info-value("supervisor-ii", info.supervisor-ii.at(0) + info.supervisor-ii.at(1))])
+    *指导教师（姓名、职称）：*#info-value("supervisor", info.supervisor.at(0) + info.supervisor.at(1)) #(if info.supervisor-ii != () [#h(1em) #info-value("supervisor-ii", info.supervisor-ii.at(0) + info.supervisor-ii.at(1))])
 
-    #fakebold[摘要：]
+    *摘要：*
 
     #[
       #set par(first-line-indent: 2em)
 
       #fake-par
-      
+
       #body
     ]
 
     #v(1em)
 
-    #fakebold[关键词：]#(("",)+ keywords.intersperse("；")).sum()
+    *关键词：*#(("",)+ keywords.intersperse("；")).sum()
   ]
 }

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -1,8 +1,9 @@
 #import "../lib.typ": documentclass, indent
+#import "../utils/globals.typ": globals
 
-// 你首先应该安装 fonts下的所有字体，
-// 如果是 Web App 上编辑，你应该手动上传这些字体文件，否则不能正常使用「楷体」和「仿宋」，导致显示错误。
-
+// 你首先应该安装 fonts下的所有字体，或在编译的时候指定字体路径：
+// typst watch template/thesis.typ --font-path ./fonts
+// 如果是 Web App 上编辑，你应该手动上传所有字体文件，否则部分字体不能正常使用，导致显示错误。
 #let (
   // 布局函数
   twoside,
@@ -25,33 +26,7 @@
   acknowledgement,
   backmatter,
 ) = documentclass(
-  doctype: "doctor", // "master" | "doctor" | "postdoc", 文档类型，默认为博士生 doctor
-  degree: "academic", // "academic" | "professional", 学位类型，默认为学术型 academic
-  anonymous: false, // 盲审模式
-  twoside: true, // 双面模式，会加入空白页，便于打印
-  // 可自定义字体，先英文字体后中文字体，应传入「宋体」、「黑体」、「楷体」、「仿宋」、「等宽」
-  // fonts: (楷体: ("Times New Roman", "FZKai-Z03S")),
-  info: (
-    title: ("基于 Typst 的", "中国科学院大学学位论文"),
-    title-en: "Typst Thesis Template of UCAS",
-    supervisors: ("李四 教授", "王五 研究员"),
-    supervisors-en: ("Professor Si Li", "Professor Wu Wang"),
-    grade: "20XX",
-    student-id: "1234567890",
-    author: "张三",
-    author-en: "Zhang San",
-    department: "中国科学院xxxx研究所",
-    department-en: "Institutes of Science and Development",
-    major: "管理科学与工程",
-    major-en: "Management Science and Engineering",
-    category: "管理学博士",
-    category-en: "Management Science",
-    supervisor: ("李四", "教授"),
-
-    // supervisor-ii: ("王五", "副教授"),
-    // supervisor-ii-en: "Professor My Supervisor",
-    submit-date: datetime.today(),
-  ),
+  ..globals,
   // 参考文献源
   bibliography: bibliography.with("ref.bib"),
 )

--- a/utils/custom-cuti.typ
+++ b/utils/custom-cuti.typ
@@ -1,1 +1,0 @@
-#import "@preview/cuti:0.2.1": *

--- a/utils/globals.typ
+++ b/utils/globals.typ
@@ -1,0 +1,31 @@
+#let globals = (
+  doctype: "master", // "master" | "doctor" | "postdoc", 文档类型，默认为博士生 doctor，为空是本科论文模板
+  degree: "academic", // "academic" | "professional", 学位类型，默认为学术型 academic
+  anonymous: false, // 盲审模式
+  twoside: true, // 双面模式，会加入空白页，便于打印
+  // 可自定义字体，先英文字体后中文字体，应传入「宋体」、「黑体」、「楷体」、「仿宋」、「等宽」
+  // fonts: (楷体: ("Times New Roman", "FZKai-Z03S")),
+  info: (
+    title: ("基于 Typst 的", "中国科学院大学学位论文"),
+    title-en: "Typst Thesis Template of UCAS",
+    supervisors: ("李四 教授", "王五 研究员"),
+    supervisors-en: ("Professor Si Li", "Professor Wu Wang"),
+    grade: "20XX",
+    student-id: "1234567890",
+    author: "张三",
+    author-en: "Zhang San",
+    department: "中国科学院xxxx研究所",
+    department-en: "Institutes of Science and Development",
+    major: "管理科学与工程",
+    major-en: "Management Science and Engineering",
+    category: "管理学博士",
+    category-en: "Management Science",
+    supervisor: ("李四", "教授"),
+
+    // supervisor-ii: ("王五", "副教授"),
+    // supervisor-ii-en: "Professor My Supervisor",
+    submit-date: datetime.today(),
+  ),
+)
+
+#let fontset = "fandol" // "windows" | "mac" | "fandol" | "adobe"，使用的字体组

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -1,3 +1,5 @@
+#import "globals.typ": fontset
+
 #let 字号 = (
   初号: 42pt,
   小初: 36pt,
@@ -18,18 +20,49 @@
   小七: 5pt,
 )
 
-#let 字体 = (
-  // 宋体，属于「有衬线字体」，一般可以等同于英文中的 Serif Font
-  // 这一行分别是「新罗马体（有衬线英文字体）」、「思源宋体（简体）」、「思源宋体」、「宋体（Windows）」、「宋体（MacOS）」
-  宋体: ("Times New Roman", "Source Han Serif SC", "Source Han Serif", "Noto Serif CJK SC", "SimSun", "Songti SC", "STSongti"),
-  // 黑体，属于「无衬线字体」，一般可以等同于英文中的 Sans Serif Font
-  // 这一行分别是「Arial（无衬线英文字体）」、「思源黑体（简体）」、「思源黑体」、「黑体（Windows）」、「黑体（MacOS）」
-  黑体: ("Arial", "Source Han Sans SC", "Source Han Sans", "Noto Sans CJK SC", "SimHei", "Heiti SC", "STHeiti"),
-  // 楷体
-  楷体: ("Times New Roman", "KaiTi", "Kaiti SC", "STKaiti", "FZKai-Z03S", "Noto Serif CJK SC"),
-  // 仿宋
-  仿宋: ("Times New Roman", "FangSong", "FangSong SC", "STFangSong", "FZFangSong-Z02S", "Noto Serif CJK SC"),
-  // 等宽字体，用于代码块环境，一般可以等同于英文中的 Monospaced Font
-  // 这一行分别是「Courier New（Windows 等宽英文字体）」、「思源等宽黑体（简体）」、「思源等宽黑体」、「黑体（Windows）」、「黑体（MacOS）」
-  等宽: ("Courier New", "Menlo", "IBM Plex Mono", "Source Han Sans HW SC", "Source Han Sans HW", "Noto Sans Mono CJK SC", "SimHei", "Heiti SC", "STHeiti"),
+#let 等宽字体 = (
+  "Courier New", "Menlo", "IBM Plex Mono", "Source Han Sans HW SC", "Source Han Sans HW", "Noto Sans Mono CJK SC", "SimHei", "Heiti SC", "STHeiti"
 )
+
+#let 字体组 = (
+  windows: (
+    宋体: ("Times New Roman", "SimSun"),
+    黑体: ("Times New Roman", "SimHei"),
+    楷体: ("Times New Roman", "KaiTi"),
+    仿宋: ("Times New Roman", "FangSong"),
+    等宽: 等宽字体,
+  ),
+  mac: (
+    宋体: ("Times New Roman", "Songti SC"),
+    黑体: ("Times New Roman", "Heiti SC"),
+    楷体: ("Times New Roman", "Kaiti SC"),
+    仿宋: ("Times New Roman", "STFangSong"),
+    等宽: 等宽字体,
+  ),
+  fandol: (
+    宋体: ("Times New Roman", "FandolSong"),
+    黑体: ("Times New Roman", "FandolHei"),
+    楷体: ("Times New Roman", "FandolKai"),
+    仿宋: ("Times New Roman", "FandolFang R"),
+    等宽: 等宽字体,
+  ),
+  adobe: (
+    宋体: ("Times New Roman", "Adobe Song Std"),
+    黑体: ("Times New Roman", "Adobe Heiti Std"),
+    楷体: ("Times New Roman", "Adobe Kaiti Std"),
+    仿宋: ("Times New Roman", "Adobe Fangsong Std"),
+    等宽: 等宽字体,
+  ),
+)
+
+#let 字体 = {
+  if fontset == "windows" {
+    字体组.windows
+  } else if fontset == "mac" {
+    字体组.mac
+  } else if fontset == "adobe" {
+    字体组.adobe
+  } else {
+    字体组.fandol
+  }
+}


### PR DESCRIPTION
- 移动了部分论文的基础属性定义到utils/globals.typ，方便引用
- 添加字体组支持功能，参考[LaTeX模板](https://github.com/mohuangrui/ucasthesis/wiki/%E5%AD%97%E4%BD%93%E9%85%8D%E7%BD%AE)中的windows, mac, fandol, adobe四个字体组全部支持
  - Fandol系列字体，可从[CTAN](https://ctan.org/pkg/fandol)下载
  - Windows系列字体包括SimSun、SimHei、Kaiti、FangSong
  - Mac系列字体包括Songti SC、Heiti SC、Kaiti SC、STFangSong
  - Adobe系列字体包括Adobe Song Std、Adobe Heiti Std、Adobe Kaiti Std、Adobe Fangsong Std，[参考](https://github.com/mingchen/mac-osx-chinese-fonts/tree/master/Adobe%20Simple%20Chinese%20Fonts)
  - 要使用对应字体，Typst会自动读取系统字体，此外对于系统没有安装的字体，也可以在编译时通过`--font-path`参数之间加载字体文件，参考命令：
  ```bash
  $ typst watch template/thesis.typ --root . --font-path ./fonts
  ```
- 更新CUTI库到0.3.0，解决了最新版typst (0.12.0)不兼容的问题